### PR TITLE
test: :white_check_mark: wait for healthy MinIO before tests & remove volume

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "s3mini",
-  "version": "0.1.1",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "s3mini",
-      "version": "0.1.1",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@aws-sdk/client-s3": "^3.802.0",

--- a/tests/compose.minio.yaml
+++ b/tests/compose.minio.yaml
@@ -1,8 +1,6 @@
 services:
   minio:
     image: quay.io/minio/minio:RELEASE.2025-04-08T15-41-24Z-cpuv1
-    volumes:
-      - ./data:/data
     ports:
       - 9002:9002
       - 9003:9003
@@ -12,4 +10,11 @@ services:
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
       MINIO_ADDRESS: ':9002'
       MINIO_CONSOLE_ADDRESS: ':9003'
+      MC_HOST_local: 'http://${MINIO_ROOT_USER}:${MINIO_ROOT_PASSWORD}@localhost:9002'
     command: minio server /data
+    healthcheck:
+      test: mc ready local
+      start_period: 5s
+      interval: 30s
+      timeout: 3s
+      retries: 3

--- a/tests/docker.js
+++ b/tests/docker.js
@@ -72,5 +72,5 @@ function run(cmd, args) {
   });
 }
 
-export const composeUp = file => run('docker', ['compose', '-f', file, 'up', '-d', '--force-recreate']);
+export const composeUp = file => run('docker', ['compose', '-f', file, 'up', '-d', '--force-recreate', '--wait']);
 export const composeDown = file => run('docker', ['compose', '-f', file, 'down', '--remove-orphans', '-v']);


### PR DESCRIPTION
fix: #15 
ref: #22, https://github.com/good-lly/s3mini/issues/15#issuecomment-2998075149

- All tests pass on MinIO.
- I removed the MinIO bind mount because I felt it didn't make sense, but please let me know if you need it back.

## Test output
<details>
<summary>Full output log</summary>

```plaintext
> s3mini@0.3.0 test:e2e
> node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.js --verbose

Providers found:  [ 'minio' ]
⏫  starting minio image …
 Network tests_default  Creating
 Network tests_default  Created
 Container tests-minio-1  Creating
 Container tests-minio-1  Created
 Container tests-minio-1  Starting
 Container tests-minio-1  Started
 Container tests-minio-1  Waiting
 Container tests-minio-1  Healthy
  console.log
    Running tests for bucket: minio

      at log (tests/_shared.test.js:15:13)

(node:89108) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
PASS Test: minio tests/minio.test.js (29.335 s)
  :::: minio ::::
    ✓ instantiates s3client
    ✓ bucket exists (13 ms)
    ✓ basic list objects (6 ms)
    ✓ basic put and get object (9 ms)
    ✓ put and get object with special characters and different types (17 ms)
    ✓ etag and if-match header check (8 ms)
    ✓ list multipart uploads and abort them all (2 ms)
    ✓ multipart upload and download (1002 ms)
    ✓ extensive list objects (12 ms)
    ✓ lists objects with pagination (28167 ms)

Test Suites: 1 passed, 1 total
Tests:       10 passed, 10 total
Snapshots:   0 total
Time:        29.365 s, estimated 30 s
Ran all test suites.
⏬  stopping minio …
 Container tests-minio-1  Stopping
 Container tests-minio-1  Stopped
 Container tests-minio-1  Removing
 Container tests-minio-1  Removed
 Network tests_default  Removing
 Network tests_default  Removed
```
</details> 