### PR TITLE
Switch to Web Crypto

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -50,8 +50,6 @@ export default [
       propertyReadSideEffects: false,
       tryCatchDeoptimization: false,
     },
-
-    external: ['node:crypto'],
   },
   {
     input: 'src/index.ts',
@@ -60,6 +58,5 @@ export default [
       format: 'esm',
     },
     plugins: [dts()],
-    external: ['node:crypto'],
   },
 ];

--- a/src/S3.ts
+++ b/src/S3.ts
@@ -316,7 +316,9 @@ class S3mini {
     credentialScope: string,
     canonicalRequest: string,
   ): Promise<string> {
-    return [C.AWS_ALGORITHM, fullDatetime, credentialScope, await U.sha256(canonicalRequest)].join('\n');
+    return [C.AWS_ALGORITHM, fullDatetime, credentialScope, U.hexFromBuffer(await U.sha256(canonicalRequest))].join(
+      '\n',
+    );
   }
 
   private async _calculateSignature(shortDatetime: string, stringToSign: string): Promise<string> {
@@ -1183,7 +1185,7 @@ class S3mini {
     const objectsXml = keys.map(key => `<Object><Key>${U.escapeXml(key)}</Key></Object>`).join('');
     const xmlBody = '<Delete>' + objectsXml + '</Delete>';
     const query = { delete: '' };
-    const sha256base64 = await U.sha256(xmlBody, 'base64');
+    const sha256base64 = U.base64FromBuffer(await U.sha256(xmlBody));
     const headers = {
       [C.HEADER_CONTENT_TYPE]: C.XML_CONTENT_TYPE,
       [C.HEADER_CONTENT_LENGTH]: Buffer.byteLength(xmlBody).toString(),

--- a/src/S3.ts
+++ b/src/S3.ts
@@ -238,12 +238,12 @@ class S3mini {
     this._checkOpts(opts);
   }
 
-  private _sign(
+  private async _sign(
     method: IT.HttpMethod,
     keyPath: string,
     query: Record<string, unknown> = {},
     headers: Record<string, string | number> = {},
-  ): { url: string; headers: Record<string, string | number> } {
+  ): Promise<{ url: string; headers: Record<string, string | number> }> {
     // Create URL without appending keyPath first
     const url = new URL(this.endpoint);
 
@@ -276,7 +276,7 @@ class S3mini {
       .join(';');
 
     const canonicalRequest = this._buildCanonicalRequest(method, url, query, canonicalHeaders, signedHeaders);
-    const stringToSign = this._buildStringToSign(fullDatetime, credentialScope, canonicalRequest);
+    const stringToSign = await this._buildStringToSign(fullDatetime, credentialScope, canonicalRequest);
     const signature = this._calculateSignature(shortDatetime, stringToSign);
     const authorizationHeader = this._buildAuthorizationHeader(credentialScope, signedHeaders, signature);
     headers[C.HEADER_AUTHORIZATION] = authorizationHeader;
@@ -311,8 +311,12 @@ class S3mini {
     return [shortDatetime, this.region, C.S3_SERVICE, C.AWS_REQUEST_TYPE].join('/');
   }
 
-  private _buildStringToSign(fullDatetime: string, credentialScope: string, canonicalRequest: string): string {
-    return [C.AWS_ALGORITHM, fullDatetime, credentialScope, U.sha256(canonicalRequest)].join('\n');
+  private async _buildStringToSign(
+    fullDatetime: string,
+    credentialScope: string,
+    canonicalRequest: string,
+  ): Promise<string> {
+    return [C.AWS_ALGORITHM, fullDatetime, credentialScope, await U.sha256(canonicalRequest)].join('\n');
   }
 
   private _calculateSignature(shortDatetime: string, stringToSign: string): string {
@@ -364,7 +368,7 @@ class S3mini {
     };
 
     const encodedKey = key ? U.uriResourceEscape(key) : '';
-    const { url, headers: signedHeaders } = this._sign(method, encodedKey, filteredOpts, baseHeaders);
+    const { url, headers: signedHeaders } = await this._sign(method, encodedKey, filteredOpts, baseHeaders);
     if (Object.keys(query).length > 0) {
       withQuery = true; // append query string to signed URL
     }
@@ -1179,7 +1183,7 @@ class S3mini {
     const objectsXml = keys.map(key => `<Object><Key>${U.escapeXml(key)}</Key></Object>`).join('');
     const xmlBody = '<Delete>' + objectsXml + '</Delete>';
     const query = { delete: '' };
-    const sha256base64 = U.sha256(xmlBody, 'base64');
+    const sha256base64 = await U.sha256(xmlBody, 'base64');
     const headers = {
       [C.HEADER_CONTENT_TYPE]: C.XML_CONTENT_TYPE,
       [C.HEADER_CONTENT_LENGTH]: Buffer.byteLength(xmlBody).toString(),

--- a/src/S3.ts
+++ b/src/S3.ts
@@ -277,7 +277,7 @@ class S3mini {
 
     const canonicalRequest = this._buildCanonicalRequest(method, url, query, canonicalHeaders, signedHeaders);
     const stringToSign = await this._buildStringToSign(fullDatetime, credentialScope, canonicalRequest);
-    const signature = this._calculateSignature(shortDatetime, stringToSign);
+    const signature = await this._calculateSignature(shortDatetime, stringToSign);
     const authorizationHeader = this._buildAuthorizationHeader(credentialScope, signedHeaders, signature);
     headers[C.HEADER_AUTHORIZATION] = authorizationHeader;
     return { url: url.toString(), headers };
@@ -319,12 +319,12 @@ class S3mini {
     return [C.AWS_ALGORITHM, fullDatetime, credentialScope, await U.sha256(canonicalRequest)].join('\n');
   }
 
-  private _calculateSignature(shortDatetime: string, stringToSign: string): string {
+  private async _calculateSignature(shortDatetime: string, stringToSign: string): Promise<string> {
     if (shortDatetime !== this.signingKeyDate) {
       this.signingKeyDate = shortDatetime;
-      this.signingKey = this._getSignatureKey(shortDatetime);
+      this.signingKey = await this._getSignatureKey(shortDatetime);
     }
-    return U.hmac(this.signingKey!, stringToSign, 'hex') as string;
+    return (await U.hmac(this.signingKey!, stringToSign, 'hex')) as string;
   }
 
   private _buildAuthorizationHeader(credentialScope: string, signedHeaders: string, signature: string): string {
@@ -1341,11 +1341,11 @@ class S3mini {
       .sort((a, b) => a.localeCompare(b))
       .join('&');
   }
-  private _getSignatureKey(dateStamp: string): Buffer {
-    const kDate = U.hmac(`AWS4${this.secretAccessKey}`, dateStamp) as Buffer;
-    const kRegion = U.hmac(kDate, this.region) as Buffer;
-    const kService = U.hmac(kRegion, C.S3_SERVICE) as Buffer;
-    return U.hmac(kService, C.AWS_REQUEST_TYPE) as Buffer;
+  private async _getSignatureKey(dateStamp: string): Promise<Buffer> {
+    const kDate = (await U.hmac(`AWS4${this.secretAccessKey}`, dateStamp)) as Buffer;
+    const kRegion = (await U.hmac(kDate, this.region)) as Buffer;
+    const kService = (await U.hmac(kRegion, C.S3_SERVICE)) as Buffer;
+    return (await U.hmac(kService, C.AWS_REQUEST_TYPE)) as Buffer;
   }
 }
 

--- a/src/S3.ts
+++ b/src/S3.ts
@@ -50,7 +50,7 @@ class S3mini {
   private requestAbortTimeout?: number;
   private logger?: IT.Logger;
   private signingKeyDate?: string;
-  private signingKey?: Buffer;
+  private signingKey?: ArrayBuffer;
 
   constructor({
     accessKeyId,
@@ -326,7 +326,7 @@ class S3mini {
       this.signingKeyDate = shortDatetime;
       this.signingKey = await this._getSignatureKey(shortDatetime);
     }
-    return (await U.hmac(this.signingKey!, stringToSign, 'hex')) as string;
+    return U.hexFromBuffer(await U.hmac(this.signingKey!, stringToSign));
   }
 
   private _buildAuthorizationHeader(credentialScope: string, signedHeaders: string, signature: string): string {
@@ -1343,11 +1343,11 @@ class S3mini {
       .sort((a, b) => a.localeCompare(b))
       .join('&');
   }
-  private async _getSignatureKey(dateStamp: string): Promise<Buffer> {
-    const kDate = (await U.hmac(`AWS4${this.secretAccessKey}`, dateStamp)) as Buffer;
-    const kRegion = (await U.hmac(kDate, this.region)) as Buffer;
-    const kService = (await U.hmac(kRegion, C.S3_SERVICE)) as Buffer;
-    return (await U.hmac(kService, C.AWS_REQUEST_TYPE)) as Buffer;
+  private async _getSignatureKey(dateStamp: string): Promise<ArrayBuffer> {
+    const kDate = await U.hmac(`AWS4${this.secretAccessKey}`, dateStamp);
+    const kRegion = await U.hmac(kDate, this.region);
+    const kService = await U.hmac(kRegion, C.S3_SERVICE);
+    return await U.hmac(kService, C.AWS_REQUEST_TYPE);
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,10 +26,6 @@ export interface Crypto {
     update: (data: Buffer | string) => { digest: (encoding?: string) => string | Buffer };
     digest: (encoding?: string) => string | Buffer;
   };
-  createHash: (algorithm: string) => {
-    update: (data: Buffer | string) => { digest: (encoding?: string) => string | Buffer };
-    digest: (encoding?: string) => string | Buffer;
-  };
 }
 
 export interface Logger {

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,16 +18,6 @@ export interface AWSHeaders {
   [k: `x-amz-${string}`]: string;
 }
 
-export interface Crypto {
-  createHmac: (
-    algorithm: string,
-    key: Buffer | string,
-  ) => {
-    update: (data: Buffer | string) => { digest: (encoding?: string) => string | Buffer };
-    digest: (encoding?: string) => string | Buffer;
-  };
-}
-
 export interface Logger {
   info: (message: string, ...args: unknown[]) => void;
   warn: (message: string, ...args: unknown[]) => void;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,24 @@
 import type { XmlValue, XmlMap, ListBucketResponse, ErrorWithCode } from './types.js';
 
 /**
+ * Turn a raw ArrayBuffer into its hexadecimal representation.
+ * @param {ArrayBuffer} buffer The raw bytes.
+ * @returns {string} Hexadecimal string
+ */
+export const hexFromBuffer = (buffer: ArrayBuffer): string => {
+  return Array.from(new Uint8Array(buffer), byte => byte.toString(16).padStart(2, '0')).join('');
+};
+
+/**
+ * Turn a raw ArrayBuffer into its base64 representation.
+ * @param {ArrayBuffer} buffer The raw bytes.
+ * @returns {string} Base64 string
+ */
+export const base64FromBuffer = (buffer: ArrayBuffer): string => {
+  return btoa(Array.from(new Uint8Array(buffer), byte => String.fromCharCode(byte)).join(''));
+};
+
+/**
  * Hash content using SHA-256
  * @param {string|Buffer} content  – data to hash
  * @param {BufferEncoding} [encoding='hex'] – hex | base64 | …

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,8 +20,8 @@ export const sha256 = async (content: string | Buffer, encoding: BufferEncoding 
  * Compute HMAC-SHA-256 of arbitrary data and return a hex string.
  * @param {string|Buffer} key      – secret key
  * @param {string|Buffer} content  – data to authenticate
- * @param {BufferEncoding} [encoding='hex'] – hex | base64 | …
- * @returns {string | Buffer} hex encoded HMAC
+ * @param {('hex' | 'base64')} [encoding] – optional string encoding
+ * @returns {string | Buffer} string encoded or raw HMAC
  */
 export const hmac = async (
   key: string | Buffer,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,5 @@
 'use strict';
-import type { Crypto, XmlValue, XmlMap, ListBucketResponse, ErrorWithCode } from './types.js';
-declare const crypto: Crypto;
-
-// Initialize crypto functions - this is needed for environments where `crypto` is not available globally
-// e.g., in Cloudflare Workers or other non-Node.js environments with nodejs_flags enabled.
-const _createHmac: Crypto['createHmac'] = crypto.createHmac || (await import('node:crypto')).createHmac;
+import type { XmlValue, XmlMap, ListBucketResponse, ErrorWithCode } from './types.js';
 
 /**
  * Hash content using SHA-256
@@ -28,9 +23,23 @@ export const sha256 = async (content: string | Buffer, encoding: BufferEncoding 
  * @param {BufferEncoding} [encoding='hex'] – hex | base64 | …
  * @returns {string | Buffer} hex encoded HMAC
  */
-export const hmac = (key: string | Buffer, content: string | Buffer, encoding?: 'hex' | 'base64'): string | Buffer => {
-  const mac = _createHmac('sha256', key).update(content);
-  return encoding ? mac.digest(encoding) : mac.digest();
+export const hmac = async (
+  key: string | Buffer,
+  content: string | Buffer,
+  encoding?: 'hex' | 'base64',
+): Promise<string | Buffer> => {
+  const encoder = new TextEncoder();
+  const secret = await globalThis.crypto.subtle.importKey(
+    'raw',
+    Buffer.from(key),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const data = encoder.encode(content.toString('utf-8'));
+  const mac = await globalThis.crypto.subtle.sign('HMAC', secret, data);
+
+  return encoding ? Buffer.from(mac).toString(encoding) : Buffer.from(mac);
 };
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,18 +20,15 @@ export const base64FromBuffer = (buffer: ArrayBuffer): string => {
 };
 
 /**
- * Hash content using SHA-256
- * @param {string|Buffer} content  – data to hash
- * @param {BufferEncoding} [encoding='hex'] – hex | base64 | …
- * @returns {string} Hex encoded hash
-
+ * Compute SHA-256 hash of arbitrary string data
+ * @param {string} content  – data to hash
+ * @returns {ArrayBuffer} Hex encoded hash
  */
-export const sha256 = async (content: string | Buffer, encoding: BufferEncoding = 'hex'): Promise<string> => {
+export const sha256 = async (content: string): Promise<ArrayBuffer> => {
   const encoder = new TextEncoder();
-  const data = encoder.encode(content.toString());
-  const hash = await globalThis.crypto.subtle.digest('SHA-256', data);
+  const data = encoder.encode(content);
 
-  return Buffer.from(hash).toString(encoding);
+  return await globalThis.crypto.subtle.digest('SHA-256', data);
 };
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,29 +32,23 @@ export const sha256 = async (content: string): Promise<ArrayBuffer> => {
 };
 
 /**
- * Compute HMAC-SHA-256 of arbitrary data and return a hex string.
- * @param {string|Buffer} key      – secret key
- * @param {string|Buffer} content  – data to authenticate
- * @param {('hex' | 'base64')} [encoding] – optional string encoding
- * @returns {string | Buffer} string encoded or raw HMAC
+ * Compute HMAC-SHA-256 of arbitrary data.
+ * @param {string|ArrayBuffer} key The key used to sign the content.
+ * @param {string} content The content to be signed.
+ * @returns {ArrayBuffer} The raw signature
  */
-export const hmac = async (
-  key: string | Buffer,
-  content: string | Buffer,
-  encoding?: 'hex' | 'base64',
-): Promise<string | Buffer> => {
+export const hmac = async (key: string | ArrayBuffer, content: string): Promise<ArrayBuffer> => {
   const encoder = new TextEncoder();
   const secret = await globalThis.crypto.subtle.importKey(
     'raw',
-    Buffer.from(key),
+    typeof key === 'string' ? encoder.encode(key) : key,
     { name: 'HMAC', hash: 'SHA-256' },
     false,
     ['sign'],
   );
-  const data = encoder.encode(content.toString('utf-8'));
-  const mac = await globalThis.crypto.subtle.sign('HMAC', secret, data);
+  const data = encoder.encode(content);
 
-  return encoding ? Buffer.from(mac).toString(encoding) : Buffer.from(mac);
+  return await globalThis.crypto.subtle.sign('HMAC', secret, data);
 };
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,9 +20,9 @@ export const base64FromBuffer = (buffer: ArrayBuffer): string => {
 };
 
 /**
- * Compute SHA-256 hash of arbitrary string data
- * @param {string} content  – data to hash
- * @returns {ArrayBuffer} Hex encoded hash
+ * Compute SHA-256 hash of arbitrary string data.
+ * @param {string} content The content to be hashed.
+ * @returns {ArrayBuffer} The raw hash
  */
 export const sha256 = async (content: string): Promise<ArrayBuffer> => {
   const encoder = new TextEncoder();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,6 @@ declare const crypto: Crypto;
 // Initialize crypto functions - this is needed for environments where `crypto` is not available globally
 // e.g., in Cloudflare Workers or other non-Node.js environments with nodejs_flags enabled.
 const _createHmac: Crypto['createHmac'] = crypto.createHmac || (await import('node:crypto')).createHmac;
-const _createHash: Crypto['createHash'] = crypto.createHash || (await import('node:crypto')).createHash;
 
 /**
  * Hash content using SHA-256
@@ -14,8 +13,12 @@ const _createHash: Crypto['createHash'] = crypto.createHash || (await import('no
  * @returns {string} Hex encoded hash
 
  */
-export const sha256 = (content: string | Buffer, encoding = 'hex'): string => {
-  return _createHash('sha256').update(content).digest(encoding) as string;
+export const sha256 = async (content: string | Buffer, encoding: BufferEncoding = 'hex'): Promise<string> => {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(content.toString());
+  const hash = await globalThis.crypto.subtle.digest('SHA-256', data);
+
+  return Buffer.from(hash).toString(encoding);
 };
 
 /**


### PR DESCRIPTION
Marking this as a draft for now.

Fixes #26.

This was originally branched off of a018fffd09e997ff7cc40caac2c392dace7a02c2 and not yet rebased. I should be able to get to that tomorrow. Just wanted to put the work out here, because I saw changes to `dev` that were made in preparation for this.

Note that the Web Crypto API is all asynchronous. This may have some minor performance implications for the library, as awaits are known to have those. Probably no difference on the macro scale though.

* [x] Rebase on the latest `dev`.
* [x] See if all use of `Buffer` can be removed, as Web Crypto uses `ArrayBuffer` and the currently used `Buffer` is a Node.js class rather than something from ECMAScript. This means platforms like Cloudflare Workers will [still need Node.js compatibility turned on](https://developers.cloudflare.com/workers/runtime-apis/nodejs/buffer/) even though the dependency on `node:crypto` is gone.