### PR TITLE
Remove dependency on `Buffer` for non-Node.js environments

### DIFF
--- a/src/S3.ts
+++ b/src/S3.ts
@@ -215,18 +215,22 @@ class S3mini {
     return { filteredOpts, conditionalHeaders };
   }
 
-  private _validateUploadPartParams(
-    key: string,
-    uploadId: string,
-    data: Buffer | string,
-    partNumber: number,
-    opts: object,
-  ): void {
-    this._checkKey(key);
-    if (!(data instanceof Buffer || typeof data === 'string')) {
+  private _validateData(data: unknown): BodyInit {
+    if (!((globalThis.Buffer && data instanceof globalThis.Buffer) || typeof data === 'string')) {
       this._log('error', C.ERROR_DATA_BUFFER_REQUIRED);
       throw new TypeError(C.ERROR_DATA_BUFFER_REQUIRED);
     }
+    return data;
+  }
+
+  private _validateUploadPartParams(
+    key: string,
+    uploadId: string,
+    data: IT.MaybeBuffer | string,
+    partNumber: number,
+    opts: object,
+  ): BodyInit {
+    this._checkKey(key);
     if (typeof uploadId !== 'string' || uploadId.trim().length === 0) {
       this._log('error', C.ERROR_UPLOAD_ID_REQUIRED);
       throw new TypeError(C.ERROR_UPLOAD_ID_REQUIRED);
@@ -236,6 +240,7 @@ class S3mini {
       throw new TypeError(`${C.ERROR_PREFIX}partNumber must be a positive integer`);
     }
     this._checkOpts(opts);
+    return this._validateData(data);
   }
 
   private async _sign(
@@ -299,13 +304,13 @@ class S3mini {
     key: string, // ‘’ allowed for bucket‑level ops
     {
       query = {}, // ?query=string
-      body = '', // string | Buffer | undefined
+      body = '', // BodyInit | undefined
       headers = {}, // extra/override headers
       tolerated = [], // [200, 404] etc.
       withQuery = false, // append query string to signed URL
     }: {
       query?: Record<string, unknown>;
-      body?: string | Buffer;
+      body?: BodyInit;
       headers?: Record<string, string | number | undefined> | IT.SSECHeaders | IT.AWSHeaders;
       tolerated?: number[];
       withQuery?: boolean;
@@ -844,13 +849,13 @@ class S3mini {
    */
   public async putObject(
     key: string,
-    data: string | Buffer,
+    data: string | IT.MaybeBuffer,
     fileType: string = C.DEFAULT_STREAM_CONTENT_TYPE,
     ssecHeaders?: IT.SSECHeaders,
     additionalHeaders?: IT.AWSHeaders,
   ): Promise<Response> {
     return this._signedRequest('PUT', key, {
-      body: data,
+      body: this._validateData(data),
       headers: {
         [C.HEADER_CONTENT_LENGTH]: U.getByteSize(data),
         [C.HEADER_CONTENT_TYPE]: fileType,
@@ -933,17 +938,17 @@ class S3mini {
   public async uploadPart(
     key: string,
     uploadId: string,
-    data: Buffer | string,
+    data: IT.MaybeBuffer | string,
     partNumber: number,
     opts: Record<string, unknown> = {},
     ssecHeaders?: IT.SSECHeaders,
   ): Promise<IT.UploadPart> {
-    this._validateUploadPartParams(key, uploadId, data, partNumber, opts);
+    const body = this._validateUploadPartParams(key, uploadId, data, partNumber, opts);
 
     const query = { uploadId, partNumber, ...opts };
     const res = await this._signedRequest('PUT', key, {
       query,
-      body: data,
+      body,
       headers: {
         [C.HEADER_CONTENT_LENGTH]: U.getByteSize(data),
         ...ssecHeaders,
@@ -1304,7 +1309,7 @@ class S3mini {
     url: string,
     method: IT.HttpMethod,
     headers: Record<string, string>,
-    body?: string | Buffer,
+    body?: BodyInit,
     toleratedStatusCodes: number[] = [],
   ): Promise<Response> {
     this._log('info', `Sending ${method} request to ${url}`, `headers: ${JSON.stringify(headers)}`);
@@ -1312,7 +1317,7 @@ class S3mini {
       const res = await fetch(url, {
         method,
         headers,
-        body: ['GET', 'HEAD'].includes(method) ? undefined : (body as string),
+        body: ['GET', 'HEAD'].includes(method) ? undefined : body,
         signal: this.requestAbortTimeout !== undefined ? AbortSignal.timeout(this.requestAbortTimeout) : undefined,
       });
       this._log('info', `Response status: ${res.status}, tolerated: ${toleratedStatusCodes.join(',')}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,3 +146,11 @@ export interface CopyObjectResult {
   etag: string;
   lastModified?: Date;
 }
+
+/**
+ * Where Buffer is available, e.g. when @types/node is loaded, we want to use it.
+ * But it should be excluded in other environments (e.g. Cloudflare).
+ */
+export type MaybeBuffer = typeof globalThis extends { Buffer?: infer B }
+  ? (B extends { new(...a: any[]): any } ? InstanceType<B> : never)
+  : never;

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,5 +152,7 @@ export interface CopyObjectResult {
  * But it should be excluded in other environments (e.g. Cloudflare).
  */
 export type MaybeBuffer = typeof globalThis extends { Buffer?: infer B }
-  ? (B extends { new(...a: any[]): any } ? InstanceType<B> : never)
+  ? B extends { new (...a: any[]): any }
+    ? InstanceType<B>
+    : never
   : never;


### PR DESCRIPTION
This is a continuation of #33. Kinda.

Running the following minimal code with [Wrangler](https://developers.cloudflare.com/workers/wrangler/) used to fail with a `ReferenceError`:

```js
import { S3mini } from '../../dist/s3mini.min.js';

const client = new S3mini({
  accessKeyId: 'AAA',
  secretAccessKey: 'BBBBBBBB',
  endpoint: 'http://localhost:9002/test',
  region: 'auto',
});

client
  .uploadPart('large-file.zip', 'demo-upload-id', '... some data to add ...', 1)
  .then(console.log, console.error);
```
```log
ReferenceError: Buffer is not defined
```

This is because `Buffer` is not part of base ECMAScript but an extension by Node.js. Now that s3mini only relies on Web Crypto APIs, this tries to remove another Node.js dependency and make it possible to use it in more environments.

1. The internal methods of the S3mini class use `BodyInit` for its request body value, this should always be compatible with `fetch()`.
2. The externally offered methods continue to accept only strings and `Buffer`s. But validation of this checks to make sure that `Buffer` is a thing, thus skipping these values in other environments.

It might also be possible to solve this by bringing `BodyInit` all the way out to the methods. But for this first PR I have chosen to keep the user inputs the same.

After this change, Wrangler returns:
```log
Error: Disallowed operation called within global scope. Asynchronous I/O (ex: fetch() or connect()), setting a timeout, and generating random values are not allowed within global scope.
```
Which suggests it can run all the library code but does not execute the `fetch()` because I am running it naively.