### PR TITLE
undefined signingKey fix

### DIFF
--- a/src/S3.ts
+++ b/src/S3.ts
@@ -291,7 +291,7 @@ class S3mini {
     }
     const canonicalRequest = `${method}\n${url.pathname}\n${this._buildCanonicalQueryString(query)}\n${canonicalHeaders}\n\n${signedHeaders}\n${C.UNSIGNED_PAYLOAD}`;
     const stringToSign = `${C.AWS_ALGORITHM}\n${fullDatetime}\n${credentialScope}\n${U.hexFromBuffer(await U.sha256(canonicalRequest))}`;
-    if (shortDatetime !== this.signingKeyDate) {
+    if (shortDatetime !== this.signingKeyDate || !this.signingKey) {
       this.signingKeyDate = shortDatetime;
       this.signingKey = await this._getSignatureKey(shortDatetime);
     }


### PR DESCRIPTION
I don't know why it happens but sometimes the signingKey is undefined. 

In my case it happens when dealing with many virtually simultaneous requests.

This PR fixes the issue for me. 

If you want to I can try to isolate this bug and create a reproduction but right now i only had time for this small PR.