### PR TITLE
feat: allow empty credentials for public bucket access

### DIFF
--- a/src/S3.ts
+++ b/src/S3.ts
@@ -144,15 +144,23 @@ class S3mini {
   }
 
   private _validateConstructorParams(accessKeyId: string, secretAccessKey: string, endpoint: string): void {
-    if (typeof accessKeyId !== 'string' || accessKeyId.trim().length === 0) {
+    if (typeof accessKeyId !== 'string') {
       throw new TypeError(C.ERROR_ACCESS_KEY_REQUIRED);
     }
-    if (typeof secretAccessKey !== 'string' || secretAccessKey.trim().length === 0) {
+    if (typeof secretAccessKey !== 'string') {
       throw new TypeError(C.ERROR_SECRET_KEY_REQUIRED);
     }
     if (typeof endpoint !== 'string' || endpoint.trim().length === 0) {
       throw new TypeError(C.ERROR_ENDPOINT_REQUIRED);
     }
+  }
+
+  /**
+   * Check if credentials are configured (non-empty).
+   * @returns true if both accessKeyId and secretAccessKey are non-empty.
+   */
+  private _hasCredentials(): boolean {
+    return this.#accessKeyId.trim().length > 0 && this.#secretAccessKey.trim().length > 0;
   }
 
   private _ensureValidUrl(raw: string): string {
@@ -274,6 +282,12 @@ class S3mini {
     if (keyPath && keyPath.length > 0) {
       url.pathname =
         url.pathname === '/' ? `/${keyPath.replace(/^\/+/, '')}` : `${url.pathname}/${keyPath.replace(/^\/+/, '')}`;
+    }
+
+    // If no credentials, return unsigned request (for public bucket access)
+    if (!this._hasCredentials()) {
+      headers[C.HEADER_HOST] = url.host;
+      return { url: url.toString(), headers };
     }
 
     const d = new Date();

--- a/tests/anonymous-access.test.js
+++ b/tests/anonymous-access.test.js
@@ -1,0 +1,110 @@
+'use strict';
+import { it, expect, describe } from '@jest/globals';
+import { S3mini } from '../dist/s3mini.js';
+
+/**
+ * Unit tests for anonymous/public S3 access (empty credentials).
+ */
+describe('Anonymous S3 access (empty credentials)', () => {
+  it('should allow initialization with empty credentials', () => {
+    expect(() => {
+      new S3mini({
+        accessKeyId: '',
+        secretAccessKey: '',
+        endpoint: 'https://public-bucket.s3.amazonaws.com',
+        region: 'us-east-1',
+      });
+    }).not.toThrow();
+  });
+
+  it('should send requests without Authorization header when credentials are empty', async () => {
+    let capturedHeaders = null;
+
+    const mockFetch = async (url, options) => {
+      capturedHeaders = options?.headers || {};
+      return new Response('<?xml version="1.0"?><ListBucketResult></ListBucketResult>', {
+        status: 200,
+        headers: { 'Content-Type': 'application/xml' },
+      });
+    };
+
+    const s3client = new S3mini({
+      accessKeyId: '',
+      secretAccessKey: '',
+      endpoint: 'https://public-bucket.s3.amazonaws.com',
+      region: 'us-east-1',
+      fetch: mockFetch,
+    });
+
+    await s3client.listObjects();
+
+    // Should NOT have Authorization header
+    expect(capturedHeaders).toBeDefined();
+    expect(capturedHeaders['Authorization']).toBeUndefined();
+    expect(capturedHeaders['authorization']).toBeUndefined();
+    
+    // Should still have Host header
+    expect(capturedHeaders['host']).toBeDefined();
+  });
+
+  it('should still require accessKeyId and secretAccessKey to be strings', () => {
+    expect(() => {
+      new S3mini({
+        accessKeyId: undefined,
+        secretAccessKey: '',
+        endpoint: 'https://bucket.s3.amazonaws.com',
+      });
+    }).toThrow(TypeError);
+
+    expect(() => {
+      new S3mini({
+        accessKeyId: '',
+        secretAccessKey: undefined,
+        endpoint: 'https://bucket.s3.amazonaws.com',
+      });
+    }).toThrow(TypeError);
+  });
+
+  it('should send signed requests when credentials are provided', async () => {
+    let capturedHeaders = null;
+
+    const mockFetch = async (url, options) => {
+      capturedHeaders = options?.headers || {};
+      return new Response('<?xml version="1.0"?><ListBucketResult></ListBucketResult>', {
+        status: 200,
+        headers: { 'Content-Type': 'application/xml' },
+      });
+    };
+
+    const s3client = new S3mini({
+      accessKeyId: 'test-access-key',
+      secretAccessKey: 'test-secret-key',
+      endpoint: 'https://bucket.s3.amazonaws.com',
+      region: 'us-east-1',
+      fetch: mockFetch,
+    });
+
+    await s3client.listObjects();
+
+    // Should have Authorization header when credentials are provided
+    expect(capturedHeaders).toBeDefined();
+    const authHeader = capturedHeaders['Authorization'] || capturedHeaders['authorization'];
+    expect(authHeader).toBeDefined();
+    expect(authHeader).toContain('AWS4-HMAC-SHA256');
+  });
+
+  it('should access real public S3 bucket (sentinel-cogs) without credentials', async () => {
+    const s3client = new S3mini({
+      accessKeyId: '',
+      secretAccessKey: '',
+      endpoint: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com',
+      region: 'us-west-2',
+    });
+
+    const objects = await s3client.listObjects('/', '', 5);
+
+    expect(objects).toBeInstanceOf(Array);
+    expect(objects.length).toBeGreaterThan(0);
+    expect(objects[0].Key).toBeDefined();
+  }, 30000); // 30s timeout for network request
+});


### PR DESCRIPTION
Allow empty accessKeyId/secretAccessKey to access public S3 buckets without signing requests.